### PR TITLE
ECDSA support, some improvements for running under FPM

### DIFF
--- a/http-signature-auth.php
+++ b/http-signature-auth.php
@@ -24,8 +24,12 @@ class InvalidAlgorithmError extends HttpSignatureError { };
 
 class HTTPSignature {
 
-	static function parse(array $headers, array $options = array())
+	static function parse(array $inheaders, array $options = array())
 	{
+		$headers = array();
+		foreach ($inheaders as $key => $value) {
+			$headers[strtolower($key)] = $value;
+		}
 		if (!array_key_exists('authorization', $headers)) {
 			throw new MissingHeaderError('no authorization header in the request');
 		}

--- a/http-signature-auth.php
+++ b/http-signature-auth.php
@@ -317,8 +317,6 @@ class HTTPSignature {
 		}
 		if (!array_key_exists('key', $options)) {
 			throw new Exception('key option is missing');
-		} elseif (!is_string($options['key'])) {
-			throw new Exception('key option is not a string');
 		}
 
 		if (!array_key_exists('headers', $options)) {

--- a/http-signature-auth.php
+++ b/http-signature-auth.php
@@ -21,6 +21,7 @@ class InvalidHeaderError extends HttpSignatureError { };
 class InvalidParamsError extends HttpSignatureError { };
 class MissingHeaderError extends HttpSignatureError { };
 class InvalidAlgorithmError extends HttpSignatureError { };
+class KeyTypeError extends HttpSignatureError { };
 
 class HTTPSignature {
 
@@ -223,8 +224,34 @@ class HTTPSignature {
 
 	static function verify(array $res, $key, $keytype)
 	{
-		if (!is_string($key)) {
-			throw new Exception('key is not a string');
+		$freekey = FALSE;
+
+		switch ($keytype) {
+		case 'hmac':
+			if (!is_string($key))
+				throw new KeyTypeError('key is not a string');
+			break;
+		case 'rsa':
+		case 'ecdsa':
+			if (is_string($key)) {
+				$key = openssl_get_publickey($key);
+				if ($key === FALSE) {
+					throw new KeyTypeError('key could not be parsed');
+				}
+				$freekey = TRUE;
+			}
+			$info = openssl_pkey_get_details($key);
+			if ($info === FALSE) {
+				throw new KeyTypeError('key is not a string or a valid key resource');
+			}
+			if ($keytype === 'rsa' && $info['type'] !== OPENSSL_KEYTYPE_RSA) {
+				throw new KeyTypeError('key and keytype arguments do not match');
+			} else if ($keytype === 'ecdsa' && $info['type'] !== OPENSSL_KEYTYPE_EC) {
+				throw new KeyTypeError('key and keytype arguments do not match');
+			}
+			break;
+		default:
+			throw new KeyTypeError('unknown key type: ' . $keytype);
 		}
 
 		$alg = explode('-', $res['params']['algorithm'], 2);
@@ -236,17 +263,23 @@ class HTTPSignature {
 		}
 		switch ($alg[0]) {
 		case 'rsa':
-			$map = array('sha1' => OPENSSL_ALGO_SHA1, 'sha256' => OPENSSL_ALGO_SHA256, 'sha512' => OPENSSL_ALGO_SHA512);
+		case 'ecdsa':
+			$map = array(
+				'sha1' => OPENSSL_ALGO_SHA1,
+				'sha256' => OPENSSL_ALGO_SHA256,
+				'sha384' => OPENSSL_ALGO_SHA384,
+				'sha512' => OPENSSL_ALGO_SHA512
+			);
 			if (!array_key_exists($alg[1], $map)) {
 				throw new InvalidAlgorithmError('unsupported algorithm');
 			}
-			$pkey = openssl_get_publickey($key);
-			if ($pkey === FALSE) {
-				throw new Exception('key could not be parsed');
+			if ($alg[1] === 'sha1' && $alg[0] !== 'rsa') {
+				throw new InvalidAlgorithmError('unsupported algorithm');
 			}
 
-			$rv = openssl_verify($res['signingString'], base64_decode($res['params']['signature']), $pkey, $map[$alg[1]]);
-			openssl_free_key($pkey);
+			$rv = openssl_verify($res['signingString'], base64_decode($res['params']['signature']), $key, $map[$alg[1]]);
+			if ($freekey)
+				openssl_free_key($key);
 
 			switch ($rv) {
 			case 0:
@@ -281,8 +314,6 @@ class HTTPSignature {
 		}
 		if (!array_key_exists('key', $options)) {
 			throw new Exception('key option is missing');
-		} elseif (!is_string($options['key'])) {
-			throw new Exception('key option is not a string');
 		}
 
 		if (!array_key_exists('headers', $options)) {
@@ -296,8 +327,38 @@ class HTTPSignature {
 			}
 		}
 
+		$key = FALSE;
+		$freekey = FALSE;
 		if (!array_key_exists('algorithm', $options)) {
-			$options['algorithm'] = 'rsa-sha256';
+			if (is_string($options['key'])) {
+				$key = openssl_get_privatekey($options['key']);
+				if ($key === FALSE) {
+					error_log(openssl_error_string());
+					throw new Exception('no algorithm given, and key option could not be parsed as a private key');
+				}
+				$freekey = TRUE;
+			} else {
+				$key = $options['key'];
+			}
+			$info = openssl_pkey_get_details($key);
+			if ($info === FALSE) {
+				throw new Exception('no algorithm given, and key option was not a valid private key');
+			}
+			switch ($info['type']) {
+			case OPENSSL_KEYTYPE_RSA:
+				$options['algorithm'] = 'rsa-sha256';
+				break;
+			case OPENSSL_KEYTYPE_EC:
+				if ($info['bits'] <= 256)
+					$options['algorithm'] = 'ecdsa-sha256';
+				else if ($info['bits'] <= 384)
+					$options['algorithm'] = 'ecdsa-sha384';
+				else
+					$options['algorithm'] = 'ecdsa-sha512';
+				break;
+			default:
+				throw new Exception('no algorithm given, and key option is of unknown key type');
+			}
 		}
 
 		if (!array_key_exists('date', $headers)) {
@@ -323,22 +384,45 @@ class HTTPSignature {
 		}
 		switch ($alg[0]) {
 		case 'rsa':
-			$map = array('sha1' => OPENSSL_ALGO_SHA1, 'sha256' => OPENSSL_ALGO_SHA256, 'sha512' => OPENSSL_ALGO_SHA512);
+		case 'ecdsa':
+			$map = array(
+				'sha256' => OPENSSL_ALGO_SHA256,
+				'sha384' => OPENSSL_ALGO_SHA384,
+				'sha512' => OPENSSL_ALGO_SHA512
+			);
 			if (!array_key_exists($alg[1], $map)) {
 				throw new InvalidAlgorithmError('unsupported algorithm');
 			}
-			$key = openssl_get_privatekey($options['key']);
-			if ($key === FALSE) {
-				error_log(openssl_error_string());
-				throw new Exception('key option could not be parsed');
+			if ($key === FALSE && is_string($options['key'])) {
+				$key = openssl_get_privatekey($options['key']);
+				if ($key === FALSE) {
+					error_log(openssl_error_string());
+					throw new Exception('key option could not be parsed');
+				}
+				$freekey = TRUE;
+			}
+			$info = openssl_pkey_get_details($key);
+			if ($info === FALSE) {
+				throw new Exception('key option was not a string or valid key resource');
+			}
+			if ($alg[0] === 'rsa' && $info['type'] !== OPENSSL_KEYTYPE_RSA) {
+				throw new KeyTypeError('key and algorithm options do not match');
+			} else if ($alg[0] === 'ecdsa' && $info['type'] !== OPENSSL_KEYTYPE_EC) {
+				throw new KeyTypeError('key and algorithm options do not match');
 			}
 
 			if (openssl_sign($data, $signature, $key, $map[$alg[1]]) === FALSE) {
 				throw new Exception('unable to sign');
 			}
+
+			if ($freekey)
+				openssl_pkey_free($key);
 			break;
 
 		case 'hmac':
+			if (!is_string($options['key'])) {
+				throw new Exception('key option is not a string');
+			}
 			$signature = hash_hmac($alg[1], $data, $options['key'], true);
 			break;
 		default:


### PR DESCRIPTION
FPM doesn't downcase headers that are returned in `getallheaders()`, so it would be nice if we did that on input to avoid needing to do it outside this code.

I've also added a second commit which adds ECDSA support and does some stricter key type checking (avoiding e.g. the possibility of a header which says `rsa-sha256` accidentally being verified using an ECDSA key)